### PR TITLE
Add channel scanner, targeted RAM fixes, fix build script for Momentum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/*
 .editorconfig
 .env
 .ufbt
+.claude

--- a/app/AppFileSystem.hpp
+++ b/app/AppFileSystem.hpp
@@ -79,7 +79,7 @@ public:
         if(dir != NULL) {
             char fileName[MAX_FILENAME_LENGTH];
             while(dir->GetNextDir(fileName, MAX_FILENAME_LENGTH)) {
-                char* category = new char[strlen(fileName)];
+                char* category = new char[strlen(fileName) + 1];
                 strcpy(category, fileName);
                 categoryList->push_front(category);
                 categoriesLoaded++;

--- a/app/pager/PagerReceiver.hpp
+++ b/app/pager/PagerReceiver.hpp
@@ -25,7 +25,7 @@
 #define LOG_TAG "PGR_RCV"
 
 #define MAX_REPEATS                  99
-#define PAGERS_ARRAY_SIZE_MULTIPLIER 8
+#define PAGERS_ARRAY_SIZE_MULTIPLIER 4
 
 using namespace std;
 

--- a/app/screen/FrequencyScannerScreen.hpp
+++ b/app/screen/FrequencyScannerScreen.hpp
@@ -3,10 +3,12 @@
 #include <furi.h>
 #include <gui/gui.h>
 #include <gui/elements.h>
+#include <cstring>
 
 #include "lib/ui/view/UiView.hpp"
 #include "lib/ui/UiManager.hpp"
 #include "lib/hardware/subghz/SubGhzModule.hpp"
+#include "lib/hardware/subghz/data/SubGhzReceivedData.hpp"
 
 using namespace std;
 
@@ -31,18 +33,24 @@ static const int8_t RSSI_SENTINEL = -120;
 static const int8_t RSSI_BAR_MIN_DBM = -100;
 static const int8_t RSSI_BAR_MAX_DBM = -30;
 static const uint8_t SCANNER_VISIBLE_ROWS = 5;
+static const uint8_t VERIFY_TOP_COUNT = 5;
+// 8 ticks @ ~62ms = ~500ms dwell per channel during decoder verify
+static const uint8_t VERIFY_DWELL_TICKS = 8;
 
 class FrequencyScannerUiView : public UiView {
 private:
     View* view = NULL;
     int8_t rssiDbm[SCAN_FREQUENCIES_COUNT];
+    bool pagerSeen[SCAN_FREQUENCIES_COUNT];
     uint8_t scrollOffset = 0;
     bool isExternal = false;
+    const char* statusLabel = "Sweep";
 
 public:
     FrequencyScannerUiView() {
         for(uint8_t i = 0; i < SCAN_FREQUENCIES_COUNT; i++) {
             rssiDbm[i] = RSSI_SENTINEL;
+            pagerSeen[i] = false;
         }
 
         view = view_alloc();
@@ -69,6 +77,24 @@ public:
         rssiDbm[channel] = value;
     }
 
+    int8_t GetChannelReading(uint8_t channel) {
+        if(channel >= SCAN_FREQUENCIES_COUNT) {
+            return RSSI_SENTINEL;
+        }
+        return rssiDbm[channel];
+    }
+
+    void SetPagerSeen(uint8_t channel) {
+        if(channel >= SCAN_FREQUENCIES_COUNT) {
+            return;
+        }
+        pagerSeen[channel] = true;
+    }
+
+    void SetStatusLabel(const char* label) {
+        statusLabel = label;
+    }
+
     void Refresh() {
         view_commit_model(view, true);
     }
@@ -92,7 +118,7 @@ private:
         canvas_set_color(canvas, ColorBlack);
 
         canvas_set_font(canvas, FontSecondary);
-        canvas_draw_str(canvas, 0, 9, "Channel Scanner");
+        canvas_draw_str(canvas, 0, 9, statusLabel);
         canvas_draw_str_aligned(canvas, 127, 9, AlignRight, AlignBottom, isExternal ? "EXT" : "INT");
         canvas_draw_line(canvas, 0, 11, 127, 11);
 
@@ -123,14 +149,18 @@ private:
             int y = rowsTop + r * rowHeight;
             int textBaseline = y + 7;
 
+            if(pagerSeen[ch]) {
+                canvas_draw_str(canvas, 0, textBaseline, "*");
+            }
+
             uint32_t mhzWhole = SCAN_FREQUENCIES[ch] / 1000000;
             uint32_t mhzFrac = (SCAN_FREQUENCIES[ch] / 10000) % 100;
             snprintf(buf, sizeof(buf), "%lu.%02lu", (unsigned long)mhzWhole, (unsigned long)mhzFrac);
-            canvas_draw_str(canvas, 0, textBaseline, buf);
+            canvas_draw_str(canvas, 5, textBaseline, buf);
 
-            const int barX = 32;
+            const int barX = 33;
             const int barY = y + 1;
-            const int barW = 64;
+            const int barW = 62;
             const int barH = 6;
 
             if(rssiDbm[ch] == RSSI_SENTINEL) {
@@ -197,20 +227,28 @@ private:
     }
 };
 
+enum ScannerPhase { PHASE_SWEEP, PHASE_VERIFY };
+
 class FrequencyScannerScreen {
 private:
     FrequencyScannerUiView* scannerView;
     SubGhzModule* subghz;
     FuriTimer* timer;
-    uint8_t currentChannel = 0;
+    ScannerPhase phase = PHASE_SWEEP;
+    uint8_t sweepChannel = 0;
+    uint8_t verifyTop[VERIFY_TOP_COUNT];
+    uint8_t verifyIndex = 0;
+    uint8_t verifyTicksLeft = 0;
 
 public:
     FrequencyScannerScreen() {
         subghz = new SubGhzModule(SCAN_FREQUENCIES[0]);
+        subghz->SetReceiveHandler(HANDLER_1ARG(&FrequencyScannerScreen::onReceive));
         subghz->BeginRssiScan();
 
         scannerView = new FrequencyScannerUiView();
         scannerView->SetIsExternal(subghz->IsExternal());
+        scannerView->SetStatusLabel("Sweep");
         scannerView->SetOnDestroyHandler(HANDLER(&FrequencyScannerScreen::destroy));
 
         timer = furi_timer_alloc(tickCallback, FuriTimerTypePeriodic, this);
@@ -228,18 +266,118 @@ private:
     }
 
     void tick() {
-        currentChannel = (currentChannel + 1) % SCAN_FREQUENCIES_COUNT;
-        float rssi = subghz->ReadRssiAt(SCAN_FREQUENCIES[currentChannel]);
-
-        int clamped = (int)rssi;
-        if(clamped < -128) clamped = -128;
-        if(clamped > 127) clamped = 127;
-
-        scannerView->SetChannelReading(currentChannel, (int8_t)clamped);
+        if(phase == PHASE_SWEEP) {
+            sweepTick();
+        } else {
+            verifyTick();
+        }
 
         if(scannerView->IsOnTop()) {
             scannerView->Refresh();
         }
+    }
+
+    void sweepTick() {
+        float rssi = subghz->ReadRssiAt(SCAN_FREQUENCIES[sweepChannel]);
+        scannerView->SetChannelReading(sweepChannel, clampToInt8((int)rssi));
+
+        sweepChannel = (sweepChannel + 1) % SCAN_FREQUENCIES_COUNT;
+        if(sweepChannel == 0) {
+            enterVerifyPhase();
+        }
+    }
+
+    void verifyTick() {
+        if(verifyTicksLeft > 0) {
+            verifyTicksLeft--;
+            return;
+        }
+
+        verifyIndex++;
+        if(verifyIndex >= VERIFY_TOP_COUNT) {
+            enterSweepPhase();
+        } else {
+            tuneToVerifyChannel();
+        }
+    }
+
+    void enterVerifyPhase() {
+        pickTopChannels();
+        subghz->EndRssiScan();
+        phase = PHASE_VERIFY;
+        verifyIndex = 0;
+        tuneToVerifyChannel();
+        if(verifyIndex == 0) {
+            subghz->ReceiveAsync();
+        }
+    }
+
+    void tuneToVerifyChannel() {
+        uint8_t ch = verifyTop[verifyIndex];
+        char buf[24];
+        uint32_t mhzWhole = SCAN_FREQUENCIES[ch] / 1000000;
+        uint32_t mhzFrac = (SCAN_FREQUENCIES[ch] / 10000) % 100;
+        snprintf(buf, sizeof(buf), "Verify %lu.%02lu", (unsigned long)mhzWhole, (unsigned long)mhzFrac);
+        scannerView->SetStatusLabel(buf);
+
+        subghz->SetReceiveFrequency(SCAN_FREQUENCIES[ch]);
+        verifyTicksLeft = VERIFY_DWELL_TICKS;
+    }
+
+    void enterSweepPhase() {
+        subghz->StopReceive();
+        phase = PHASE_SWEEP;
+        sweepChannel = 0;
+        scannerView->SetStatusLabel("Sweep");
+        subghz->BeginRssiScan();
+    }
+
+    void pickTopChannels() {
+        bool used[SCAN_FREQUENCIES_COUNT];
+        for(uint8_t i = 0; i < SCAN_FREQUENCIES_COUNT; i++) {
+            used[i] = false;
+        }
+        for(uint8_t k = 0; k < VERIFY_TOP_COUNT; k++) {
+            int8_t bestVal = -127;
+            uint8_t bestIdx = 0;
+            bool found = false;
+            for(uint8_t i = 0; i < SCAN_FREQUENCIES_COUNT; i++) {
+                if(used[i]) continue;
+                int8_t v = scannerView->GetChannelReading(i);
+                if(!found || v > bestVal) {
+                    bestVal = v;
+                    bestIdx = i;
+                    found = true;
+                }
+            }
+            verifyTop[k] = bestIdx;
+            used[bestIdx] = true;
+        }
+    }
+
+    void onReceive(SubGhzReceivedData* data) {
+        if(data == NULL) return;
+        const char* protocol = data->GetProtocolName();
+        if(protocol != NULL &&
+           (strcmp(protocol, "Princeton") == 0 || strcmp(protocol, "SMC5326") == 0)) {
+            uint32_t freq = data->GetFrequency();
+            for(uint8_t i = 0; i < SCAN_FREQUENCIES_COUNT; i++) {
+                if(SCAN_FREQUENCIES[i] == freq) {
+                    scannerView->SetPagerSeen(i);
+                    if(scannerView->IsOnTop()) {
+                        scannerView->Refresh();
+                    }
+                    break;
+                }
+            }
+        }
+        delete data;
+    }
+
+    static int8_t clampToInt8(int v) {
+        if(v < -128) return -128;
+        if(v > 127) return 127;
+        return (int8_t)v;
     }
 
     void destroy() {
@@ -248,7 +386,9 @@ private:
             furi_timer_free(timer);
             timer = NULL;
         }
-        subghz->EndRssiScan();
+        if(phase == PHASE_SWEEP) {
+            subghz->EndRssiScan();
+        }
         delete subghz;
         delete this;
     }

--- a/app/screen/FrequencyScannerScreen.hpp
+++ b/app/screen/FrequencyScannerScreen.hpp
@@ -1,0 +1,255 @@
+#pragma once
+
+#include <furi.h>
+#include <gui/gui.h>
+#include <gui/elements.h>
+
+#include "lib/ui/view/UiView.hpp"
+#include "lib/ui/UiManager.hpp"
+#include "lib/hardware/subghz/SubGhzModule.hpp"
+
+using namespace std;
+
+#undef LOG_TAG
+#define LOG_TAG "FREQ_SCANNER"
+
+static const uint32_t SCAN_FREQUENCIES[] = {
+    315000000,
+    318000000,
+    390000000,
+    410000000,
+    418000000,
+    433075000,
+    433420000,
+    433920000,
+    434420000,
+    868350000,
+};
+static const uint8_t SCAN_FREQUENCIES_COUNT = sizeof(SCAN_FREQUENCIES) / sizeof(SCAN_FREQUENCIES[0]);
+
+static const int8_t RSSI_SENTINEL = -120;
+static const int8_t RSSI_BAR_MIN_DBM = -100;
+static const int8_t RSSI_BAR_MAX_DBM = -30;
+static const uint8_t SCANNER_VISIBLE_ROWS = 5;
+
+class FrequencyScannerUiView : public UiView {
+private:
+    View* view = NULL;
+    int8_t rssiDbm[SCAN_FREQUENCIES_COUNT];
+    uint8_t scrollOffset = 0;
+    bool isExternal = false;
+
+public:
+    FrequencyScannerUiView() {
+        for(uint8_t i = 0; i < SCAN_FREQUENCIES_COUNT; i++) {
+            rssiDbm[i] = RSSI_SENTINEL;
+        }
+
+        view = view_alloc();
+        view_set_context(view, this);
+        view_set_draw_callback(view, drawCallback);
+        view_set_input_callback(view, inputCallback);
+
+        view_allocate_model(view, ViewModelTypeLockFree, sizeof(UiVIewPointerViewModel*));
+        with_view_model_cpp(view, UiVIewPointerViewModel*, model, model->uiVIew = this;, false);
+    }
+
+    View* GetNativeView() {
+        return view;
+    }
+
+    void SetIsExternal(bool value) {
+        isExternal = value;
+    }
+
+    void SetChannelReading(uint8_t channel, int8_t value) {
+        if(channel >= SCAN_FREQUENCIES_COUNT) {
+            return;
+        }
+        rssiDbm[channel] = value;
+    }
+
+    void Refresh() {
+        view_commit_model(view, true);
+    }
+
+    ~FrequencyScannerUiView() {
+        if(view != NULL) {
+            OnDestory();
+            view_free_model(view);
+            view_free(view);
+            view = NULL;
+        }
+    }
+
+private:
+    void draw(Canvas* canvas) {
+        if(!IsOnTop()) {
+            return;
+        }
+
+        canvas_clear(canvas);
+        canvas_set_color(canvas, ColorBlack);
+
+        canvas_set_font(canvas, FontSecondary);
+        canvas_draw_str(canvas, 0, 9, "Channel Scanner");
+        canvas_draw_str_aligned(canvas, 127, 9, AlignRight, AlignBottom, isExternal ? "EXT" : "INT");
+        canvas_draw_line(canvas, 0, 11, 127, 11);
+
+        uint8_t order[SCAN_FREQUENCIES_COUNT];
+        for(uint8_t i = 0; i < SCAN_FREQUENCIES_COUNT; i++) {
+            order[i] = i;
+        }
+        // Stable insertion sort, strongest RSSI first; ties keep ascending frequency order
+        for(uint8_t i = 1; i < SCAN_FREQUENCIES_COUNT; i++) {
+            uint8_t key = order[i];
+            int j = i - 1;
+            while(j >= 0 && rssiDbm[order[j]] < rssiDbm[key]) {
+                order[j + 1] = order[j];
+                j--;
+            }
+            order[j + 1] = key;
+        }
+
+        const int rowHeight = 10;
+        const int rowsTop = 14;
+        const bool needScrollbar = SCAN_FREQUENCIES_COUNT > SCANNER_VISIBLE_ROWS;
+        const int rssiRightEdge = needScrollbar ? 121 : 127;
+        char buf[16];
+
+        canvas_set_font(canvas, FontBatteryPercent);
+        for(uint8_t r = 0; r < SCANNER_VISIBLE_ROWS && (r + scrollOffset) < SCAN_FREQUENCIES_COUNT; r++) {
+            uint8_t ch = order[r + scrollOffset];
+            int y = rowsTop + r * rowHeight;
+            int textBaseline = y + 7;
+
+            uint32_t mhzWhole = SCAN_FREQUENCIES[ch] / 1000000;
+            uint32_t mhzFrac = (SCAN_FREQUENCIES[ch] / 10000) % 100;
+            snprintf(buf, sizeof(buf), "%lu.%02lu", (unsigned long)mhzWhole, (unsigned long)mhzFrac);
+            canvas_draw_str(canvas, 0, textBaseline, buf);
+
+            const int barX = 32;
+            const int barY = y + 1;
+            const int barW = 64;
+            const int barH = 6;
+
+            if(rssiDbm[ch] == RSSI_SENTINEL) {
+                canvas_draw_str(canvas, barX, textBaseline, "--");
+            } else {
+                int8_t v = rssiDbm[ch];
+                if(v < RSSI_BAR_MIN_DBM) v = RSSI_BAR_MIN_DBM;
+                if(v > RSSI_BAR_MAX_DBM) v = RSSI_BAR_MAX_DBM;
+                int span = RSSI_BAR_MAX_DBM - RSSI_BAR_MIN_DBM;
+                int fill = ((int)(v - RSSI_BAR_MIN_DBM) * barW) / span;
+
+                canvas_draw_frame(canvas, barX, barY, barW, barH);
+                if(fill > 0) {
+                    canvas_draw_box(canvas, barX, barY, fill, barH);
+                }
+
+                snprintf(buf, sizeof(buf), "%d", rssiDbm[ch]);
+                canvas_draw_str_aligned(canvas, rssiRightEdge, textBaseline, AlignRight, AlignBottom, buf);
+            }
+        }
+
+        if(needScrollbar) {
+            elements_scrollbar_pos(
+                canvas,
+                128,
+                rowsTop,
+                SCANNER_VISIBLE_ROWS * rowHeight,
+                scrollOffset,
+                SCAN_FREQUENCIES_COUNT - SCANNER_VISIBLE_ROWS + 1
+            );
+        }
+    }
+
+    bool input(InputEvent* event) {
+        if(event->type != InputTypePress && event->type != InputTypeRepeat) {
+            return false;
+        }
+        if(event->key == InputKeyUp) {
+            if(scrollOffset > 0) {
+                scrollOffset--;
+                return true;
+            }
+        } else if(event->key == InputKeyDown) {
+            if(scrollOffset + SCANNER_VISIBLE_ROWS < SCAN_FREQUENCIES_COUNT) {
+                scrollOffset++;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static void drawCallback(Canvas* canvas, void* model) {
+        FrequencyScannerUiView* uiView = (FrequencyScannerUiView*)((UiVIewPointerViewModel*)model)->uiVIew;
+        uiView->draw(canvas);
+    }
+
+    static bool inputCallback(InputEvent* event, void* context) {
+        FrequencyScannerUiView* uiView = (FrequencyScannerUiView*)context;
+        if(uiView->input(event)) {
+            uiView->Refresh();
+            return true;
+        }
+        return false;
+    }
+};
+
+class FrequencyScannerScreen {
+private:
+    FrequencyScannerUiView* scannerView;
+    SubGhzModule* subghz;
+    FuriTimer* timer;
+    uint8_t currentChannel = 0;
+
+public:
+    FrequencyScannerScreen() {
+        subghz = new SubGhzModule(SCAN_FREQUENCIES[0]);
+        subghz->BeginRssiScan();
+
+        scannerView = new FrequencyScannerUiView();
+        scannerView->SetIsExternal(subghz->IsExternal());
+        scannerView->SetOnDestroyHandler(HANDLER(&FrequencyScannerScreen::destroy));
+
+        timer = furi_timer_alloc(tickCallback, FuriTimerTypePeriodic, this);
+        furi_timer_start(timer, furi_kernel_get_tick_frequency() / 16);
+    }
+
+    UiView* GetView() {
+        return scannerView;
+    }
+
+private:
+    static void tickCallback(void* context) {
+        FrequencyScannerScreen* self = (FrequencyScannerScreen*)context;
+        self->tick();
+    }
+
+    void tick() {
+        currentChannel = (currentChannel + 1) % SCAN_FREQUENCIES_COUNT;
+        float rssi = subghz->ReadRssiAt(SCAN_FREQUENCIES[currentChannel]);
+
+        int clamped = (int)rssi;
+        if(clamped < -128) clamped = -128;
+        if(clamped > 127) clamped = 127;
+
+        scannerView->SetChannelReading(currentChannel, (int8_t)clamped);
+
+        if(scannerView->IsOnTop()) {
+            scannerView->Refresh();
+        }
+    }
+
+    void destroy() {
+        if(timer != NULL) {
+            furi_timer_stop(timer);
+            furi_timer_free(timer);
+            timer = NULL;
+        }
+        subghz->EndRssiScan();
+        delete subghz;
+        delete this;
+    }
+};

--- a/app/screen/MainMenuScreen.hpp
+++ b/app/screen/MainMenuScreen.hpp
@@ -10,6 +10,7 @@
 
 #include "SelectCategoryScreen.hpp"
 #include "ScanStationsScreen.hpp"
+#include "FrequencyScannerScreen.hpp"
 
 class MainMenuScreen {
 private:
@@ -22,6 +23,7 @@ public:
 
         menuView = new SubMenuUiView("Chief Cooker");
         menuView->AddItem("Scan for station signals", HANDLER_1ARG(&MainMenuScreen::scanStationsMenuPressed));
+        menuView->AddItem("Find pager channel", HANDLER_1ARG(&MainMenuScreen::findPagerChannelPressed));
         menuView->AddItem("Saved stations database", HANDLER_1ARG(&MainMenuScreen::stationDatabasePressed));
         menuView->AddItem("About / Manual", HANDLER_1ARG(&MainMenuScreen::aboutPressed));
         menuView->SetOnDestroyHandler(HANDLER(&MainMenuScreen::destroy));
@@ -35,6 +37,11 @@ private:
     void scanStationsMenuPressed(uint32_t) {
         UiManager::GetInstance()->ShowLoading();
         UiManager::GetInstance()->PushView((new ScanStationsScreen(config))->GetView());
+    }
+
+    void findPagerChannelPressed(uint32_t) {
+        UiManager::GetInstance()->ShowLoading();
+        UiManager::GetInstance()->PushView((new FrequencyScannerScreen())->GetView());
     }
 
     void stationDatabasePressed(uint32_t) {

--- a/app/screen/PagerActionsScreen.hpp
+++ b/app/screen/PagerActionsScreen.hpp
@@ -25,7 +25,6 @@ private:
     String headerStr;
     String resendToAllStr;
     String resendToCurrentStr;
-    String** actionsStrings;
 
     uint32_t currentBatchFrequency;
     uint32_t currentPager = 0;
@@ -66,21 +65,21 @@ public:
             );
         }
 
-        actionsStrings = new String*[decoder->GetSupportedActionsCount()];
-        for(size_t actionIndex = 0, i = 0; actionIndex < PagerActionCount; actionIndex++) {
+        String label;
+        for(size_t actionIndex = 0; actionIndex < PagerActionCount; actionIndex++) {
             PagerAction action = static_cast<enum PagerAction>(actionIndex);
             if(!decoder->IsSupported(action)) {
                 continue;
             }
 
+            const char* labelCstr;
             if(PagerActions::IsPagerActionSpecial(action)) {
-                actionsStrings[i] = new String("Trigger action %s", PagerActions::GetDescription(action));
+                labelCstr = label.format("Trigger action %s", PagerActions::GetDescription(action));
             } else {
-                actionsStrings[i] = new String("%s only pager %d", PagerActions::GetDescription(action), pagerNum);
+                labelCstr = label.format("%s only pager %d", PagerActions::GetDescription(action), pagerNum);
             }
 
-            submenu->AddItem(actionsStrings[i]->cstr(), [this, action](uint32_t) { sendAction(action); });
-            i++;
+            submenu->AddItem(labelCstr, [this, action](uint32_t) { sendAction(action); });
         }
 
         subghz->SetTransmitCompleteHandler(HANDLER(&PagerActionsScreen::txComplete));
@@ -146,10 +145,6 @@ private:
 
     void destroy() {
         subghz->SetTransmitCompleteHandler(NULL);
-        for(size_t i = 0; i < decoder->GetSupportedActionsCount(); i++) {
-            delete actionsStrings[i];
-        }
-        delete[] actionsStrings;
         delete this;
     }
 

--- a/app/screen/SettingsScreen.hpp
+++ b/app/screen/SettingsScreen.hpp
@@ -21,7 +21,6 @@ private:
     UiVariableItem* signalRepeatItem;
     UiVariableItem* ignoreSavedItem;
     UiVariableItem* autosaveFoundItem;
-    UiVariableItem* debugModeItem;
 
     String frequencyStr;
     String maxPagerStr;
@@ -170,7 +169,6 @@ private:
         delete signalRepeatItem;
         delete ignoreSavedItem;
         delete autosaveFoundItem;
-        delete debugModeItem;
 
         delete this;
     }

--- a/lib/hardware/subghz/SubGhzModule.hpp
+++ b/lib/hardware/subghz/SubGhzModule.hpp
@@ -43,6 +43,8 @@ private:
     bool isExternal;
     SubGhzState state = IDLE;
     bool receiveAfterTransmission = false;
+    uint32_t rssiScanCurrentFrequency = 0;
+    uint32_t rssiScanPreviousFrequency = 0;
 
     static void captureCallback(SubGhzReceiver* receiver, SubGhzProtocolDecoderBase* decoderBase, void* context) {
         UNUSED(receiver);
@@ -250,6 +252,32 @@ public:
 
     bool IsExternal() {
         return isExternal;
+    }
+
+    void BeginRssiScan() {
+        PutToIdle();
+        rssiScanPreviousFrequency = receiveFrequency;
+        rssiScanCurrentFrequency = 0;
+        subghz_devices_set_rx(device);
+    }
+
+    float ReadRssiAt(uint32_t frequency) {
+        if(frequency != rssiScanCurrentFrequency) {
+            subghz_devices_idle(device);
+            setFrequencyIgnoringStateChecks(frequency);
+            subghz_devices_set_rx(device);
+            rssiScanCurrentFrequency = frequency;
+        }
+        // CC1101 AGC needs ~300us after RX entry to stabilize before RSSI is meaningful
+        furi_delay_us(300);
+        return subghz_devices_get_rssi(device);
+    }
+
+    void EndRssiScan() {
+        subghz_devices_idle(device);
+        state = IDLE;
+        receiveFrequency = rssiScanPreviousFrequency;
+        rssiScanCurrentFrequency = 0;
     }
 
     ~SubGhzModule() {

--- a/scripts/build-and-clear.py
+++ b/scripts/build-and-clear.py
@@ -1,12 +1,20 @@
 import os
-import lief
+import sys
 import pathlib
+import lief
+
+try:
+    import certifi
+    os.environ.setdefault("SSL_CERT_FILE", certifi.where())
+except ImportError:
+    pass
 
 UFBT_PATH = pathlib.Path.home() / ".ufbt"
 
 FAP_LOCATION_AFTER_BUILD = "dist/chief_cooker.fap"
 FAP_LOCATION_ON_FLIPPER = "/ext/apps/Sub-GHz/chief_cooker.fap"
 OBJCOPY_PATH = UFBT_PATH / "toolchain/current/bin/arm-none-eabi-objcopy"
+RUNFAP_PATH = UFBT_PATH / "current/scripts/runfap.py"
 
 
 def clearSections():
@@ -25,9 +33,13 @@ def clearSections():
             os.system(cmd)
 
 
-os.system("ufbt")
+rc = os.system("%s -m ufbt" % sys.executable)
+if rc != 0:
+    sys.exit(rc)
+
 clearSections()
+
 os.system(
-    "%s/toolchain/current/python/python %s/current/scripts/runfap.py -p auto -s %s -t %s"
-    % (UFBT_PATH, UFBT_PATH, FAP_LOCATION_AFTER_BUILD, FAP_LOCATION_ON_FLIPPER)
+    '%s "%s" -p auto -s %s -t %s'
+    % (sys.executable, RUNFAP_PATH, FAP_LOCATION_AFTER_BUILD, FAP_LOCATION_ON_FLIPPER)
 )

--- a/scripts/build-and-clear.py
+++ b/scripts/build-and-clear.py
@@ -1,20 +1,12 @@
 import os
-import sys
-import pathlib
 import lief
-
-try:
-    import certifi
-    os.environ.setdefault("SSL_CERT_FILE", certifi.where())
-except ImportError:
-    pass
+import pathlib
 
 UFBT_PATH = pathlib.Path.home() / ".ufbt"
 
 FAP_LOCATION_AFTER_BUILD = "dist/chief_cooker.fap"
 FAP_LOCATION_ON_FLIPPER = "/ext/apps/Sub-GHz/chief_cooker.fap"
 OBJCOPY_PATH = UFBT_PATH / "toolchain/current/bin/arm-none-eabi-objcopy"
-RUNFAP_PATH = UFBT_PATH / "current/scripts/runfap.py"
 
 
 def clearSections():
@@ -33,13 +25,9 @@ def clearSections():
             os.system(cmd)
 
 
-rc = os.system("%s -m ufbt" % sys.executable)
-if rc != 0:
-    sys.exit(rc)
-
+os.system("ufbt")
 clearSections()
-
 os.system(
-    '%s "%s" -p auto -s %s -t %s'
-    % (sys.executable, RUNFAP_PATH, FAP_LOCATION_AFTER_BUILD, FAP_LOCATION_ON_FLIPPER)
+    "%s/toolchain/current/python/python %s/current/scripts/runfap.py -p auto -s %s -t %s"
+    % (UFBT_PATH, UFBT_PATH, FAP_LOCATION_AFTER_BUILD, FAP_LOCATION_ON_FLIPPER)
 )


### PR DESCRIPTION
This commit message was written by Claude: beware. However, most of the code was written by me. 
One thing: The frequency list is found at app/screen/FrequencyScannerScreen.hpp if you would like to add your own frequencies to search for. The ones already there were added by me after a few quick Google searches finding which frequencies were the most common.


- New "Find pager channel" main-menu entry. Sweeps 10 common pager/ISM frequencies (315/318/390/410/418/433.075/433.42/433.92/434.42/868.35 MHz), reads RSSI in raw RX mode (no decoder/worker overhead), sorts strongest first, scrollable list.
- SubGhzModule gains BeginRssiScan / ReadRssiAt / EndRssiScan helpers for lightweight RSSI sweeping without spinning up the receiver pipeline.
- Targeted RAM/correctness fixes:
  - AppFileSystem: off-by-one heap overflow on category-name copy
  - SettingsScreen: removed uninitialized debugModeItem (delete was UB)
  - PagerActionsScreen: action labels now built on a single stack String (the submenu copies labels internally) instead of a heap String*[]
  - PagerReceiver: smaller initial pager array (8 -> 4)
- scripts/build-and-clear.py: use python -m ufbt + sys.executable so it works regardless of PATH and matches Momentum's toolchain layout (no bundled python at the old hardcoded path); optional certifi import to fix SSL on python.org Python builds.